### PR TITLE
Add optional workspace ID setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Set your [API token](https://github.com/toggl/toggl_api_docs#api-token)
 let g:toggl_api_token = "b51ff78xxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
+Set your [workspace ID](https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md) (optional)
+*Note: If you don't set this, toggl.vim will default to your first workspace*
+
+```vim
+let g:toggl_workspace_id = 987654321
+```
+
 Start task
 
 ```vim

--- a/autoload/toggl.vim
+++ b/autoload/toggl.vim
@@ -57,7 +57,11 @@ function! toggl#list() abort
 endfunction
 
 function! toggl#projects() abort
-  let wid = toggl#workspaces#get()[0].id
+  if !exists("g:toggl_workspace_id")
+    let wid = toggl#workspaces#get()[0].id
+  else
+    let wid = g:toggl_workspace_id
+  endif
   return toggl#workspaces#projects(wid)
 endfunction
 
@@ -73,7 +77,11 @@ function! s:get_pid(project_name) abort
 endfunction
 
 function! toggl#tags() abort
-  let wid = toggl#workspaces#get()[0].id
+  if !exists("g:toggl_workspace_id")
+    let wid = toggl#workspaces#get()[0].id
+  else
+    let wid = g:toggl_workspace_id
+  endif
   return toggl#workspaces#tags(wid)
 endfunction
 


### PR DESCRIPTION
By default, Toggl creates one Workspace for a user. Some users have
multiple workspaces, however, so the user should be able to specify the
workspace ID for the workspace they want to use toggl.vim with. Now they
can optionally specify that workspace ID with `let g:toggl_workspace_id = 987654321`
and toggl.vim will use that workspace. It does not verify that the
workspace exists or that the user has permission to write to that
workspace.
